### PR TITLE
Fix link on title image

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,1 +1,1 @@
-[![Neon](https://github.com/neondatabase/.github/assets/27310414/f026c202-e4dd-4393-803c-c9515387ec60)](https://neon.tech)
+[![Neon](https://github-production-user-asset-6210df.s3.amazonaws.com/27310414/238704008-f026c202-e4dd-4393-803c-c9515387ec60.jpeg)](https://neon.tech)


### PR DESCRIPTION
To make a link on an image lead to some webpage the image should be a real image (jpeg, png, etc).
`https://github.com/neondatabase/.github/assets/27310414/f026c202-e4dd-4393-803c-c9515387ec60` it's not, this URL redirects to an image (which I use in the PR).